### PR TITLE
Move GPG setup to the end

### DIFF
--- a/zsh/.zshenv
+++ b/zsh/.zshenv
@@ -24,14 +24,6 @@ export CVS_RSH="ssh"
 export CVSEDITOR="vim"
 export RSYNC_RSH="ssh"
 
-# Setup GPG.
-export GPG_TTY=$(tty);
-if which gpgconf > /dev/null 2>&1; then
-  export GPG_AGENT_INFO=$(gpgconf --list-dirs agent-socket)
-  export SSH_AUTH_SOCK=$(gpgconf --list-dirs agent-ssh-socket)
-  gpg-connect-agent updatestartuptty /bye > /dev/null
-fi
-
 # OS-specific environment.
 case $OSTYPE in
   linux*)
@@ -55,6 +47,14 @@ export LANG=en_US.UTF-8
 # Source local environment.
 if [[ -f ~/.zshenv.local ]]; then
   source ~/.zshenv.local
+fi
+
+# Setup GPG.
+export GPG_TTY=$(tty);
+if which gpgconf > /dev/null 2>&1; then
+  export GPG_AGENT_INFO=$(gpgconf --list-dirs agent-socket)
+  export SSH_AUTH_SOCK=$(gpgconf --list-dirs agent-ssh-socket)
+  gpg-connect-agent updatestartuptty /bye > /dev/null
 fi
 
 # vim: ft=zsh


### PR DESCRIPTION
This fixes and issue with gpg-agent trying to read locale settings,
e.g.:

Warning: Failed to set locale category LC_TIME to en_DE.
Warning: Failed to set locale category LC_COLLATE to en_DE.
Warning: Failed to set locale category LC_MONETARY to en_DE.
Warning: Failed to set locale category LC_MESSAGES to en_DE.
Warning: Failed to set locale category LC_NUMERIC to en_DE.
Warning: Failed to set locale category LC_TIME to en_DE.
Warning: Failed to set locale category LC_COLLATE to en_DE.
Warning: Failed to set locale category LC_MONETARY to en_DE.